### PR TITLE
VBID-2656 Allow max_chars for string field

### DIFF
--- a/rest/fields.py
+++ b/rest/fields.py
@@ -116,12 +116,12 @@ class WriteOnce(Field):
 
 class String(Field):
   def __init__(self, *args, **kwargs):
-    self.max_chars = kwargs.pop('max_chars', None)
+    self.trim_to = kwargs.pop('trim_to', None)
     super(String, self).__init__(*args, **kwargs)
 
   def coerce(self, value):
-    if self.max_chars:
-      return unicode(value)[:self.max_chars]
+    if self.trim_to:
+      return unicode(value)[:self.trim_to]
     return unicode(value)
 
 

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -54,8 +54,8 @@ class FieldTest(TestCase):
     self.assertEquals(u'H\xc3\xa4nsel',
         fields.String().coerce(u'H\xc3\xa4nsel'))
 
-  def test_string_coercion_with_max_chars(self):
-    self.assertEquals('19103', fields.String(max_chars=5).coerce('19103-1212'))
+  def test_string_coercion_with_trim_to(self):
+    self.assertEquals('19103', fields.String(trim_to=5).coerce('19103-1212'))
 
   def test_boolean_coercion(self):
     self.assertTrue(fields.Bool().coerce(True))


### PR DESCRIPTION
- example: trimming zip+4 to a 5 digit zip
