### PR TITLE
CSV features

### DIFF
--- a/rest/__init__.py
+++ b/rest/__init__.py
@@ -6,6 +6,7 @@ from exceptions import ValueError
 from flask import Response
 from flask import request
 from functools import wraps
+from StringIO import StringIO
 from werkzeug.wrappers import BaseResponse
 
 from schema import Schema
@@ -76,29 +77,61 @@ def view(func):
     return _serialize(func(*args, **kwargs))
   return wrapped
 
-def csv_upload(schema):
+def _check_csv_schema(schema, row, row_number):
+  csv_row_schema = schema(row_number=row_number)
+  if not csv_row_schema(row):
+    raise CsvValidationError('CSV failed validation', csv_row_schema)
+  return csv_row_schema
+
+def csv_upload(schema, fieldnames=None):
   """
   validate each row of a CSV on upload - if a row doesn't pass validation, HTTP
-  400 with a body of the validation errors out of the rest schema
+  400 with a body of the validation errors out of the rest schema.
+  CSV must either have a header or a sequence of fieldnames must be given
 
   the generator object will be passed to the view function as the rows argument
   and will return a rest.Schema for each row.  if nothing calls the generator,
   no validation will occur
   """
-  def check_schema(row, row_number):
-    csv_row_schema = schema(row_number=row_number)
-    if not csv_row_schema(row):
-      raise CsvValidationError('CSV failed validation', csv_row_schema)
-    return csv_row_schema
-
   def decorator(view):
     @wraps(view)
     def view_wrapper(*args, **kwargs):
       body = request.files['file'].stream
-      rows = (check_schema(row, i) \
-          for i, row in enumerate(csv.DictReader(body), start=1))
+      rows = (_check_csv_schema(schema, row, i) \
+          for i, row in enumerate(csv.DictReader(body, fieldnames=fieldnames),
+            start=1))
       try:
         return view(rows, *args, **kwargs)
+      except CsvValidationError as exc:
+        return error(exc.schema)
+
+    return view_wrapper
+  return decorator
+
+def json_csv_upload(fieldnames=None):
+  """
+  similar to `csv_upload`, but handle bodies like {"csv": "name,a,b\nhonk,c,d"}
+  CSV must either have a header, or a sequence of fieldnames must be given will
+  400 if missing a "csv" key or if that key is missing a value
+
+  doesn't perform validation, instead returns a generator in the "rows" argument
+  that yields a dict representing the row and a row number, 1-indexed
+  """
+  def decorator(wrapped):
+    @wraps(wrapped)
+    @view
+    def view_wrapper(*args, **kwargs):
+      body = kwargs.get('data')
+      if not body or not body.get('csv'):
+        return error({'client': ['"csv" key cannot be empty']})
+
+      csv_data = body.get('csv').encode('utf8')
+
+      kwargs['rows'] = ((row, i) \
+          for i, row in enumerate(csv.DictReader(StringIO(csv_data),
+            fieldnames=fieldnames), start=1))
+      try:
+        return wrapped(*args, **kwargs)
       except CsvValidationError as exc:
         return error(exc.schema)
 

--- a/test/test_rest.py
+++ b/test/test_rest.py
@@ -3,6 +3,7 @@ from StringIO import StringIO
 
 from flask import Flask
 from flask.ext.testing import TestCase
+from json import dumps
 from json import loads
 from nose.plugins.skip import SkipTest
 
@@ -74,6 +75,20 @@ class TestCSVUpload(TestCase):
         self.seen_dog_names.append(schema.dog_type.get())
       return rest.created({'csv': 'created'})
 
+    @self.app.route('/csv_with_fieldnames', methods=['POST'])
+    @rest.csv_upload(CSVSchema, fieldnames=('dog_type','food','pounds',))
+    def csv_with_fieldnames(rows):
+      for schema in rows:
+        self.seen_dog_names.append(schema.dog_type.get())
+      return rest.created({'csv': 'created'})
+
+    @self.app.route('/csv_json/<id_one>/<id_two>', methods=['POST'])
+    @rest.json_csv_upload(fieldnames=('dog_type','food','pounds',))
+    def csv_json(id_one, id_two, rows, data):
+      for row, row_number in rows:
+        self.seen_dog_names.append(row.get('dog_type'))
+      return rest.created({'csv': 'created'})
+
   def create_app(self):
     self.app = Flask('TestCSVUpload')
     return self.app
@@ -85,6 +100,22 @@ class TestCSVUpload(TestCase):
     resp = self.client.post('/csv', headers=self.csv_headers)
 
     self.assert400(resp)
+
+  def test_csv_upload_without_header(self):
+    """
+    it should 400 if it doesn't know which fields to use for rows
+    """
+    data = "great dane,cured meats,200\n" \
+      "shibe,doge food,20\n" \
+      "'strodog,kibble,65"
+
+    resp = self.client.post('/csv', data={
+      'file': (StringIO(data), 'test.csv')}, headers=self.csv_headers)
+
+    self.assert400(resp)
+    body = loads(resp.data)
+
+    self.assertIn('cannot be empty', body['food'])
 
   def test_csv_upload_with_invalid_data(self):
     """
@@ -153,6 +184,75 @@ class TestCSVUpload(TestCase):
       headers=self.csv_headers)
 
     self.assert_status(resp, 201)
+    self.assertIn(u'Hänsel', self.seen_dog_names)
+    self.assertIn(u'niño', self.seen_dog_names)
+    self.assertIn(u'foxes', self.seen_dog_names)
+
+  def test_json_csv_upload_with_no_csv_key(self):
+    headers = {
+      'content-type': 'text/json'
+    }
+
+    data = "foxes,cured meats,3200\n" \
+      "H\xc3\xa4nsel,pies,1500\n" \
+      "ni\xc3\xb1o,foods,43\n"
+
+    o = {
+      'this_key_isnt_called_csv': data
+    }
+
+    resp = self.client.post('/csv_json/h/f', data=dumps(o), headers=headers)
+    self.assert400(resp)
+
+    body = loads(resp.data)
+
+    self.assertIn('"csv" key cannot be empty', body['client'])
+
+  def test_json_csv_upload_with_header(self):
+    """
+    it should handle request bodies like {"csv": "name,a,b\nhonk,c,d"}
+    """
+    headers = {
+      'content-type': 'text/json'
+    }
+
+    data = "dog_type,food,pounds\n" \
+      "foxes,cured meats,3200\n" \
+      "H\xc3\xa4nsel,pies,1500\n" \
+      "ni\xc3\xb1o,foods,43\n"
+
+    o = {
+      'csv': data
+    }
+
+    resp = self.client.post('/csv_json/some_id/some_other',
+        data=dumps(o), headers=headers)
+    self.assert_status(resp, 201)
+
+    self.assertIn(u'Hänsel', self.seen_dog_names)
+    self.assertIn(u'niño', self.seen_dog_names)
+    self.assertIn(u'foxes', self.seen_dog_names)
+
+  def test_json_csv_with_defined_fieldnames(self):
+    """
+    it should use the given fieldnames in making dicts for the schema
+    """
+    headers = {
+      'content-type': 'text/json'
+    }
+
+    data = "foxes,cured meats,3200\n" \
+      "H\xc3\xa4nsel,pies,1500\n" \
+      "ni\xc3\xb1o,foods,43\n"
+
+    o = {
+      'csv': data
+    }
+
+    resp = self.client.post('/csv_json/1/2',
+      data=dumps(o), headers=headers)
+    self.assert_status(resp, 201)
+
     self.assertIn(u'Hänsel', self.seen_dog_names)
     self.assertIn(u'niño', self.seen_dog_names)
     self.assertIn(u'foxes', self.seen_dog_names)


### PR DESCRIPTION
- add `fieldnames` kwarg for passing column names along with the schema
- `#json_csv_upload` to handle ye olde `{"csv": "1,2,3\3,2,1"}` - won't do
  validation, will give view function a `rows` generator that yields (dict,
  row_number)
