### PR TITLE
add options to List for specifying valid values

### DIFF
--- a/rest/__init__.py
+++ b/rest/__init__.py
@@ -29,9 +29,9 @@ from fields import URL
 from fields import WriteOnce
 from fields import WriteOnly
 
+from validators import length
 from validators import multiple_choice
 from validators import nonempty
-from validators import length
 from validators import number_range
 from validators import regex
 from validators import required

--- a/rest/encoding.py
+++ b/rest/encoding.py
@@ -35,6 +35,7 @@ class JsonEncoding(object):
       el.pop('__namespace__')
     return el
 
+
 class XmlEncoding(object):
   def __init__(self, namespace):
     self.namespace = namespace
@@ -115,6 +116,7 @@ class XmlEncoding(object):
       else:
         d[t.tag] = text
     return d
+
 
 def encoder(request, namespace='body'):
   best = request.accept_mimetypes.best_match([

--- a/rest/fields.py
+++ b/rest/fields.py
@@ -192,8 +192,17 @@ class Dollars(Field):
 
 
 class List(Field):
+  def __init__(self, value=None, validators=[], default=None, options=[]):
+    self.options = options
+    super(List, self).__init__(value, validators, default)
+
   def coerce(self, value):
-    return list(value)
+    items = list(value)
+    if self.options:
+      for item in items:
+        if item not in self.options:
+          raise ValueError('Invalid selection %s' % item)
+    return items
 
 
 class TruthyOnlyList(Field):

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from decimal import Decimal
 from unittest import TestCase
 from nose.tools import raises
+from nose.tools import assert_raises
 
 from rest import fields
 
@@ -106,6 +107,19 @@ class FieldTest(TestCase):
   def test_dollars_coercion(self):
     self.assertEquals(Decimal('1.10'), fields.Dollars().coerce('1.10'))
     self.assertEquals(Decimal('1.10'), fields.Dollars().coerce(1.10))
+
+  def test_list_coercion(self):
+    self.assertIn('1', fields.List().coerce(['1', '2', '3']))
+    self.assertIn('2', fields.List().coerce(['1', '2', '3']))
+    self.assertIn('3', fields.List().coerce(['1', '2', '3']))
+
+  def test_list_coercion_with_options_list(self):
+    list_coerce = fields.List(options=['bigdog', 'strodog']).coerce
+
+    assert_raises(ValueError, list_coerce, ['smalldog'])
+    assert_raises(ValueError, list_coerce, ['strodog', 'smalldog'])
+    self.assertIn('strodog', list_coerce(['strodog', 'bigdog']))
+    self.assertIn('bigdog', list_coerce(['strodog', 'bigdog']))
 
   def test_datetime_coercion(self):
     self.assertEquals(datetime(2012, 4, 20, 16, 20, 0, 0),

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -63,6 +63,19 @@ class TestSchema(TestCase):
     self.assertEquals(1, len(schema._errors))
     self.assertEquals(['not a valid Zip'], schema._errors['zip_code'])
 
+  def test_list_with_valid_options(self):
+    class ListSchema(rest.Schema):
+      dogs = rest.List(options=['strodog', 'bigdog'])
+
+    schema = ListSchema()
+    self.assertTrue(schema({'dogs': ['strodog']}))
+    self.assertFalse(schema({'dogs': ['smalldog']}))
+    self.assertFalse(schema({'dogs': ['strodog', 'smalldog']}))
+    self.assertTrue(schema({'dogs': ['bigdog', 'strodog']}))
+
+    schema({'dogs': ['strodog', 'smalldog', 'yapdog']})
+    self.assertIn('Invalid selection smalldog', schema._errors['dogs'])
+
   def test_serialized_set(self):
     schema = FriendSchema()
 


### PR DESCRIPTION
- add `options` kwarg to `fields.List` to allow setting valid options
  for a List
- some whitespace and alphabetizing cleanup
