### PR TITLE
Upgrade to python 3

### DIFF
--- a/rest/__init__.py
+++ b/rest/__init__.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 import flask
 import unicodecsv as csv
+import six
 
 from flask import Response
 from functools import wraps
-from io import BytesIO
 from werkzeug.wrappers import BaseResponse
 
 from .schema import Schema
@@ -138,7 +138,7 @@ def json_csv_upload(fieldnames):
     return (obj, row_number, errors)
 
   def csv_reader(byte_string):
-    csv_data   = BytesIO(byte_string)
+    csv_data   = six.BytesIO(byte_string)
     csv_reader = csv.reader(csv_data)
 
     for i, row in enumerate(csv_reader, start=1):

--- a/rest/__init__.py
+++ b/rest/__init__.py
@@ -1,45 +1,44 @@
+from __future__ import absolute_import
 import flask
 import unicodecsv as csv
 
-from exceptions import ValueError
-
 from flask import Response
 from functools import wraps
-from StringIO import StringIO
+from io import BytesIO
 from werkzeug.wrappers import BaseResponse
 
-from schema import Schema
+from .schema import Schema
 
-from model import Model
+from .model import Model
 
-from fields import Bool
-from fields import DateTime
-from fields import Dict
-from fields import Dollars
-from fields import Email
-from fields import Float
-from fields import Int
-from fields import List
-from fields import NoneInt
-from fields import NoneString
-from fields import ReadOnly
-from fields import String
-from fields import StringBool
-from fields import TruthyOnlyList
-from fields import URL
-from fields import WriteOnce
-from fields import WriteOnly
+from .fields import Bool
+from .fields import DateTime
+from .fields import Dict
+from .fields import Dollars
+from .fields import Email
+from .fields import Float
+from .fields import Int
+from .fields import List
+from .fields import NoneInt
+from .fields import NoneString
+from .fields import ReadOnly
+from .fields import String
+from .fields import StringBool
+from .fields import TruthyOnlyList
+from .fields import URL
+from .fields import WriteOnce
+from .fields import WriteOnly
 
-from validators import email
-from validators import length
-from validators import multiple_choice
-from validators import nonempty
-from validators import number_range
-from validators import regex
-from validators import required
-from validators import url
+from .validators import email
+from .validators import length
+from .validators import multiple_choice
+from .validators import nonempty
+from .validators import number_range
+from .validators import regex
+from .validators import required
+from .validators import url
 
-from encoding import encoder
+from .encoding import encoder
 
 
 class CsvValidationError(ValueError):
@@ -72,11 +71,10 @@ def view(func):
       else:
         try:
           kwargs['data'] = codec.decode(request)
-        except Exception, e:
+        except Exception as e:
           return error({
             'client': [str(e)]
           })
-
     return _serialize(func(*args, **kwargs))
   return wrapped
 
@@ -139,8 +137,8 @@ def json_csv_upload(fieldnames):
 
     return (obj, row_number, errors)
 
-  def csv_reader(string):
-    csv_data   = StringIO(string)
+  def csv_reader(byte_string):
+    csv_data   = BytesIO(byte_string)
     csv_reader = csv.reader(csv_data)
 
     for i, row in enumerate(csv_reader, start=1):

--- a/rest/encoding.py
+++ b/rest/encoding.py
@@ -1,8 +1,11 @@
+from __future__ import absolute_import
 import json
 
 from collections import defaultdict
 from decimal import Decimal
 from xml.etree import ElementTree
+import six
+from six.moves import map
 
 
 # This class is for backwards compatability with Python 2.6
@@ -20,7 +23,7 @@ class JsonEncoding(object):
 
   def decode(self, request):
     if request.data:
-      return json.loads(request.data)
+      return json.loads(request.get_data(as_text=True))
     else:
       return {}
 
@@ -50,7 +53,8 @@ class XmlEncoding(object):
       root = self.encode_list(dct)
     else:
       root = self.encode_dict(dct)
-    return ElementTree.tostring(root, encoding='UTF-8')
+    return "<?xml version='1.0' encoding='unicode'?>\n" + \
+        ElementTree.tostring(root, encoding='unicode')
 
   def encode_dict(self, dct):
     return self.dict_to_element_tree(dct)
@@ -76,7 +80,7 @@ class XmlEncoding(object):
       namespace = self.namespace
     root = ElementTree.Element(namespace)
     for k, vs in dct.items():
-      if not hasattr(vs, '__iter__'):
+      if not hasattr(vs, '__iter__') or isinstance(vs, str):
         vs = [vs]
 
       for v in vs:
@@ -99,15 +103,15 @@ class XmlEncoding(object):
     if children:
       dd = defaultdict(list)
       for dc in map(self.etree_to_dict, children):
-        for k, v in dc.iteritems():
+        for k, v in six.iteritems(dc):
           dd[k].append(v)
 
       values = {}
-      for k, vs in dd.iteritems():
+      for k, vs in six.iteritems(dd):
         values[k] = vs[0] if len(vs) == 1 else vs
       d = {t.tag: values}
     if t.attrib:
-      d[t.tag].update(('@' + k, v) for k, v in t.attrib.iteritems())
+      d[t.tag].update(('@' + k, v) for k, v in six.iteritems(t.attrib))
     if t.text:
       text = t.text.strip()
       if children or t.attrib:

--- a/rest/encoding.py
+++ b/rest/encoding.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import sys
 import json
 
 from collections import defaultdict
@@ -53,8 +54,11 @@ class XmlEncoding(object):
       root = self.encode_list(dct)
     else:
       root = self.encode_dict(dct)
-    return "<?xml version='1.0' encoding='unicode'?>\n" + \
-        ElementTree.tostring(root, encoding='unicode')
+    if sys.version_info[0] >= 3:
+      return b"<?xml version='1.0' encoding='UTF-8'?>\n" + \
+          ElementTree.tostring(root, encoding='UTF-8')
+    else:
+      return ElementTree.tostring(root, encoding='UTF-8')
 
   def encode_dict(self, dct):
     return self.dict_to_element_tree(dct)

--- a/rest/fields.py
+++ b/rest/fields.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from datetime import datetime
 from decimal import Decimal
 from locale import atof
@@ -5,6 +6,7 @@ from locale import atoi
 
 from rest.validators import email
 from rest.validators import url
+import six
 
 
 class Field(object):
@@ -125,8 +127,8 @@ class String(Field):
 
   def coerce(self, value):
     if self.trim_to:
-      return unicode(value)[:self.trim_to]
-    return unicode(value)
+      return six.text_type(value)[:self.trim_to]
+    return six.text_type(value)
 
 
 class NoneString(String):
@@ -164,7 +166,7 @@ class Int(Field):
     if value == '':
       value = '0'
     try:
-      if isinstance(value, basestring):
+      if isinstance(value, six.string_types):
         return atoi(value)
       else:
         return int(value)
@@ -177,7 +179,7 @@ class NoneInt(Field):
     if value == '' or value is None:
       return None
     try:
-      if isinstance(value, basestring):
+      if isinstance(value, six.string_types):
         return atoi(value)
       else:
         return int(value)
@@ -193,7 +195,7 @@ class Float(Field):
     if value == '':
       value = '0.0'
     try:
-      if isinstance(value, basestring):
+      if isinstance(value, six.string_types):
         return atof(value)
       else:
         return float(value)

--- a/rest/model.py
+++ b/rest/model.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from copy import copy
 
 

--- a/rest/schema.py
+++ b/rest/schema.py
@@ -4,7 +4,7 @@ class Schema(object):
   def combined_errors(self, *args):
     errors = []
     for schema in args:
-      errors.extend(schema._errors.items())
+      errors.extend(list(schema._errors.items()))
     return dict(errors)
 
   def __init__(self, **kwargs):

--- a/rest/util.py
+++ b/rest/util.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from flask import request
 
 

--- a/rest/validators.py
+++ b/rest/validators.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import re
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,14 @@ setup(
   packages  = ['rest'],
 
   install_requires = [
-    'Flask         == 0.10',
-    'unicodecsv    == 0.9.4',
+    'Flask         == 1.0.4',
+    'unicodecsv    == 0.14.1',
   ],
 
   test_suite = 'nose.collector',
 
   tests_require = [
-    'Flask-Testing == 0.4.1',
-    'nose          == 1.3.0',
+    'Flask-Testing == 0.7.1',
+    'nose          == 1.3.7',
   ]
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
   packages  = ['rest'],
 
   install_requires = [
-    'Flask         == 1.0.4',
+    'Flask         == 1.0.2',
     'unicodecsv    == 0.14.1',
     'six           == 1.14.0'
   ],

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
   install_requires = [
     'Flask         == 1.0.4',
     'unicodecsv    == 0.14.1',
+    'six           == 1.14.0'
   ],
 
   test_suite = 'nose.collector',

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,6 @@
+from __future__ import absolute_import
 from flask import Flask
-from flask.ext.testing import TestCase
+from flask_testing import TestCase
 
 app = Flask(__name__)
 

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -49,7 +49,7 @@ class TestXmlEncoding(unittest.TestCase):
       'age':      23,
       'name':     'steve',
       'friends':  ['bob', 'frank']
-    })
+    }).decode()
 
     self.assertTrue('<friends>bob</friends>' in xml)
     self.assertTrue('<friends>frank</friends>' in xml)
@@ -59,14 +59,14 @@ class TestXmlEncoding(unittest.TestCase):
     xml = self.codec.encode({
       'name':     'steve',
       'income':   None,
-    })
+    }).decode()
 
     self.assertTrue('None' not in xml)
     self.assertTrue('<name>steve</name>' in xml)
     self.assertTrue('<income />' in xml)
 
   def test_boolean_value(self):
-    xml = self.codec.encode({'cool': True})
+    xml = self.codec.encode({'cool': True}).decode()
     self.assertTrue('<cool>true</cool>' in xml)
 
   def test_json_excludes_namespace(self):
@@ -132,7 +132,7 @@ class TestEncoding(TestCase):
       ''',
       headers = self._accept('text/xml'))
     preamble = resp.get_data(as_text=True).split('\n')[0]
-    self.assertEquals("<?xml version='1.0' encoding='unicode'?>", preamble)
+    self.assertEquals("<?xml version='1.0' encoding='UTF-8'?>", preamble)
 
   def test_schema_name_returned_for_xml(self):
     class UserSchema(rest.Schema):

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import locale
 
 from datetime import datetime

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from unittest import TestCase
 from nose.exc import SkipTest
 

--- a/test/test_rest.py
+++ b/test/test_rest.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
-from StringIO import StringIO
+from __future__ import absolute_import
+from io import StringIO
+from io import BytesIO
 
 from flask import Flask
-from flask.ext.testing import TestCase
+from flask_testing import TestCase
 from json import dumps
 from json import loads
 from nose.plugins.skip import SkipTest
@@ -12,6 +14,7 @@ import rest
 from test import ViewTestCase
 
 from rest.schema import Schema
+import six
 
 
 class TestRest(ViewTestCase):
@@ -40,7 +43,7 @@ class TestSimpleApp(TestCase):
     resp = self.client.post('/post', data=body)
     self.assert200(resp)
 
-    self.assertEquals(u'Nina\u2019s', loads(resp.data)['hi'])
+    self.assertEquals(u'Nina\u2019s', loads(resp.get_data(as_text=True))['hi'])
     self.assertEquals(u'Nina\u2019s', self.last_post['hi'])
 
   def test_unicode_without_encoding_header(self):
@@ -48,7 +51,7 @@ class TestSimpleApp(TestCase):
     body = u'{"hi": "L\u2019Acadie pour Elle"}'
     resp = self.client.post('/post', data=body)
     self.assertEquals(400, resp.status_code)
-    body = loads(resp.data)
+    body = loads(resp.get_data(as_text=True))
     self.assertEquals({
       'client': ['Expecting property name: line 1 column 1 (char 1)']
     }, body)
@@ -120,10 +123,10 @@ class TestCSVUpload(TestCase):
       "'strodog,kibble,65"
 
     resp = self.client.post('/csv', data={
-      'file': (StringIO(data), 'test.csv')}, headers=self.csv_headers)
+      'file': (BytesIO(data.encode()), 'test.csv')}, headers=self.csv_headers)
 
     self.assert400(resp)
-    body = loads(resp.data)
+    body = loads(resp.get_data(as_text=True))
 
     self.assertIn('cannot be empty', body['food'])
 
@@ -139,10 +142,10 @@ class TestCSVUpload(TestCase):
       "'strodog,kibble,65"
 
     resp = self.client.post('/csv', data={
-      'file': (StringIO(data), 'test.csv')}, headers=self.csv_headers)
+      'file': (BytesIO(data.encode()), 'test.csv')}, headers=self.csv_headers)
 
     self.assert400(resp)
-    body = loads(resp.data)
+    body = loads(resp.get_data(as_text=True))
 
     self.assertIn('cannot be empty', body['food'])
 
@@ -154,7 +157,7 @@ class TestCSVUpload(TestCase):
       "'strodog,kibble,65"
 
     resp = self.client.post('/csv', data={
-      'file': (StringIO(data), 'test.csv')}, headers=self.csv_headers)
+      'file': (BytesIO(data.encode()), 'test.csv')}, headers=self.csv_headers)
 
     self.assert_status(resp, 201)
 
@@ -170,7 +173,7 @@ class TestCSVUpload(TestCase):
       "'strodog,kibble,65\n"
 
     resp = self.client.post('/csv', data={
-      'file': (StringIO(data), 'test.csv')}, headers=self.csv_headers)
+      'file': (BytesIO(data.encode()), 'test.csv')}, headers=self.csv_headers)
 
     self.assert_status(resp, 201)
 
@@ -186,11 +189,11 @@ class TestCSVUpload(TestCase):
     """
     data = "dog_type,food,pounds\n" \
       "foxes,cured meats,3200\n" \
-      "H\xc3\xa4nsel,pies,1500\n" \
-      "ni\xc3\xb1o,foods,43\n"
+      "H\u00e4nsel,pies,1500\n" \
+      "ni\u00f1o,foods,43\n"
 
     resp = self.client.post('/csv',
-      data={'file': (StringIO(data), 'test.csv')},
+      data={'file': (BytesIO(data.encode()), 'test.csv')},
       headers=self.csv_headers)
 
     self.assert_status(resp, 201)
@@ -213,8 +216,7 @@ class TestCSVUpload(TestCase):
 
     resp = self.client.post('/csv_json/h/f', data=dumps(o), headers=headers)
     self.assert400(resp)
-
-    body = loads(resp.data)
+    body = loads(resp.get_data(as_text=True))
 
     self.assertIn('"csv" key cannot be empty', body['client'])
 
@@ -227,8 +229,8 @@ class TestCSVUpload(TestCase):
     }
 
     data = "foxes,cured meats,3200\n" \
-      "H\xc3\xa4nsel,pies,1500\n" \
-      "ni\xc3\xb1o,foods,43\n"
+      "H\u00e4nsel,pies,1500\n" \
+      "ni\u00f1o,foods,43\n"
 
     o = {
       'csv': data
@@ -238,7 +240,7 @@ class TestCSVUpload(TestCase):
         data=dumps(o), headers=headers)
     self.assert_status(resp, 201)
 
-    body = loads(resp.data)
+    body = loads(resp.get_data(as_text=True))
 
     names = [d.get('dog_type') for d in body]
 
@@ -257,7 +259,7 @@ class TestCSVUpload(TestCase):
       '''"slow horses",grass food,33'''
 
     o = {
-      'csv': unicode(data)
+      'csv': six.text_type(data)
     }
 
     fieldnames = ('name','feed','pounds',)

--- a/test/test_rest.py
+++ b/test/test_rest.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-from io import StringIO
-from io import BytesIO
 
 from flask import Flask
 from flask_testing import TestCase
@@ -123,7 +121,8 @@ class TestCSVUpload(TestCase):
       "'strodog,kibble,65"
 
     resp = self.client.post('/csv', data={
-      'file': (BytesIO(data.encode()), 'test.csv')}, headers=self.csv_headers)
+      'file': (six.BytesIO(data.encode('utf-8')), 'test.csv')},
+      headers=self.csv_headers)
 
     self.assert400(resp)
     body = loads(resp.get_data(as_text=True))
@@ -142,7 +141,8 @@ class TestCSVUpload(TestCase):
       "'strodog,kibble,65"
 
     resp = self.client.post('/csv', data={
-      'file': (BytesIO(data.encode()), 'test.csv')}, headers=self.csv_headers)
+      'file': (six.BytesIO(data.encode('utf-8')), 'test.csv')},
+      headers=self.csv_headers)
 
     self.assert400(resp)
     body = loads(resp.get_data(as_text=True))
@@ -157,7 +157,7 @@ class TestCSVUpload(TestCase):
       "'strodog,kibble,65"
 
     resp = self.client.post('/csv', data={
-      'file': (BytesIO(data.encode()), 'test.csv')}, headers=self.csv_headers)
+      'file': (six.BytesIO(data.encode()), 'test.csv')}, headers=self.csv_headers)
 
     self.assert_status(resp, 201)
 
@@ -173,7 +173,7 @@ class TestCSVUpload(TestCase):
       "'strodog,kibble,65\n"
 
     resp = self.client.post('/csv', data={
-      'file': (BytesIO(data.encode()), 'test.csv')}, headers=self.csv_headers)
+      'file': (six.BytesIO(data.encode()), 'test.csv')}, headers=self.csv_headers)
 
     self.assert_status(resp, 201)
 
@@ -187,13 +187,13 @@ class TestCSVUpload(TestCase):
     """
     it should be able to handle unicode characters
     """
-    data = "dog_type,food,pounds\n" \
-      "foxes,cured meats,3200\n" \
-      "H\u00e4nsel,pies,1500\n" \
-      "ni\u00f1o,foods,43\n"
+    data = u"dog_type,food,pounds\n" \
+      u"foxes,cured meats,3200\n" \
+      u"H\u00e4nsel,pies,1500\n" \
+      u"ni\u00f1o,foods,43\n"
 
     resp = self.client.post('/csv',
-      data={'file': (BytesIO(data.encode()), 'test.csv')},
+      data={'file': (six.BytesIO(data.encode('utf-8')), 'test.csv')},
       headers=self.csv_headers)
 
     self.assert_status(resp, 201)
@@ -228,9 +228,9 @@ class TestCSVUpload(TestCase):
       'content-type': 'text/json'
     }
 
-    data = "foxes,cured meats,3200\n" \
-      "H\u00e4nsel,pies,1500\n" \
-      "ni\u00f1o,foods,43\n"
+    data = u"foxes,cured meats,3200\n" \
+      u"H\u00e4nsel,pies,1500\n" \
+      u"ni\u00f1o,foods,43\n"
 
     o = {
       'csv': data

--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from datetime import datetime
 from unittest import TestCase
 


### PR DESCRIPTION
 * ran python-modernize to upgrade python 2 to python 3
 * manually fixed tests for python 3 compatibility
 * most of the changes here revolve around how python 3 handles
   bytes/unicode differently than python 2. For example, flask
   responses in python 3 come back as byte strings, which is
   why all the tests changed to call `response.get_data(as_text=True)`
   instead of just accessing directly `response.data`
 * also upgraded dependencies since some older versions
   had bugs/caused errors when run in a python 3 environment