### PR TITLE
QUICKFIX add field validation for non-noneable rest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
 python:
-  - "2.7"
+  - "3.7"
 install: python setup.py install
 script: python setup.py test

--- a/rest/fields.py
+++ b/rest/fields.py
@@ -55,7 +55,7 @@ class Field(object):
 
   def set(self, value):
     if value is None:
-      return
+      raise ValueError('Invalid value %s' % value)
     return self._set(value)
 
   def _set(self, value):

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
 
   install_requires = [
     'Flask         == 1.0.2',
+    'Werkzeug      == 0.16.1',
     'unicodecsv    == 0.14.1',
     'six           == 1.14.0'
   ],

--- a/test/test_fields.py
+++ b/test/test_fields.py
@@ -40,6 +40,12 @@ class FieldTest(TestCase):
 
     field.set('bye')
 
+  @raises(ValueError)
+  def test_set_none_on_field(self):
+    field = fields.ReadOnly(fields.String('hi'))
+
+    field.set(None)
+
   @raises(Exception)
   def test_write_only(self):
     field = fields.WriteOnly(fields.String('hi'))


### PR DESCRIPTION
  Fields that allow `None` should overrride the `set()` method on
  field.
  - Updated the base Field class to raise an exception when attempting
  to set `None` value
  - Updated .travis.yml file to use supported python version
  - Locked Werkzeug dependency to working version to avoid https://github.com/jarus/flask-testing/issues/143